### PR TITLE
Add Laravel 5.6 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ $countries = \Countries::getByRegion(\Countries::$REGION_AMERICAS);
 $countries = \Countries::getByRegion(\Countries::$REGION_ASIA);
 $countries = \Countries::getByRegion(\Countries::$REGION_EUROPE);
 $countries = \Countries::getByRegion(\Countries::$REGION_OCEANIA);
-$countries = \Countries::getByRegion(\Countries::$REGION_NONE); // Antarctica amongst others.
+$countries = \Countries::getByRegion(\Countries::$REGION_ANTARCTIC);
 ```
 
 Results will be returned as Country objects. These objects have the following helper methods :

--- a/composer.json
+++ b/composer.json
@@ -18,14 +18,14 @@
 	],
 	"require": {
 		"illuminate/support": "~5.1",
-        "mledoze/countries": "~1.8"
+        "mledoze/countries": "~2.0"
 	},
 	"require-dev": {
-		"phpunit/phpunit" : "~5.2",
+		"phpunit/phpunit" : "~7.0",
         "mockery/mockery": "0.9.*",
-        "orchestra/testbench": "~3.1",
+        "orchestra/testbench": "~3.6",
         "satooshi/php-coveralls": "~1.0",
-        "illuminate/foundation": "^5.1.3"
+        "laravel/framework": "^5.6"
 	},
 	"autoload": {
 		"psr-4": {

--- a/src/RegionsTrait.php
+++ b/src/RegionsTrait.php
@@ -12,5 +12,5 @@ trait RegionsTrait
     public static $REGION_ASIA = 'Asia';
     public static $REGION_EUROPE = 'Europe';
     public static $REGION_OCEANIA = 'Oceania';
-    public static $REGION_NONE = '';
+    public static $REGION_ANTARCTIC = 'Antarctic';
 }

--- a/tests/CountriesRepositoryTest.php
+++ b/tests/CountriesRepositoryTest.php
@@ -51,7 +51,7 @@ class CountriesRepositoryTest extends LaravelCountriesTestCase
     /** @test */
     public function it_gets_countries_by_subregion()
     {
-        $results = $this->countries->getBySubregion('Northern America');
+        $results = $this->countries->getBySubregion('North America');
         $codes = array_column($results, 'cca2');
 
         $this->assertContainsOnlyInstancesOf(\Lykegenes\LaravelCountries\Country::class, $results);

--- a/tests/RegionsTest.php
+++ b/tests/RegionsTest.php
@@ -12,7 +12,7 @@ class RegionsTest extends LaravelCountriesTestCase
         $asia = $this->countries->getByRegion(\Countries::$REGION_ASIA);
         $europe = $this->countries->getByRegion(\Countries::$REGION_EUROPE);
         $oceania = $this->countries->getByRegion(\Countries::$REGION_OCEANIA);
-        $others = $this->countries->getByRegion(\Countries::$REGION_NONE);
+        $antarctic = $this->countries->getByRegion(\Countries::$REGION_ANTARCTIC);
 
         // No region should be empty
         $this->assertNotEmpty($africa);
@@ -20,10 +20,10 @@ class RegionsTest extends LaravelCountriesTestCase
         $this->assertNotEmpty($asia);
         $this->assertNotEmpty($europe);
         $this->assertNotEmpty($oceania);
-        $this->assertNotEmpty($others);
+        $this->assertNotEmpty($antarctic);
 
         // Make sure the totals match
         $this->assertEquals(count($this->countries->getRawData()),
-            count($africa) + count($americas) + count($asia) + count($europe) + count($oceania) + count($others));
+            count($africa) + count($americas) + count($asia) + count($europe) + count($oceania) + count($antarctic));
     }
 }


### PR DESCRIPTION
For reasons see #6 

`mledoze/countries` no longer contains countries with empty regions, they are all using the new region `Antarctic` now. As such I removed `\Countries::$REGION_NONE` and added `\Countries::$REGION_ANTARCTIC`.

Also, the subregion `Northern America` was renamed to `North America`. I updated the tests to reflect that.

Both of these changes are compatibility breaking, so this should be a new major version.